### PR TITLE
Update dependencies to latest stable versions

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,17 +9,17 @@
 
   :dependencies
   [[org.clojure/clojure "1.10.3"]
-   [com.amperity/ken "1.0.1"]
-   [com.stuartsierra/component "1.0.0"]
+   [com.amperity/ken "1.0.2"]
+   [com.stuartsierra/component "1.1.0"]
    [io.honeycomb.libhoney/libhoney-java "1.5.0"]]
 
   :profiles
   {:dev
    {:dependencies
-    [[org.slf4j/slf4j-nop "1.7.35"]]}
+    [[org.slf4j/slf4j-nop "1.7.36"]]}
 
    :repl
    {:source-paths ["dev"]
     :jvm-opts ["-XX:-OmitStackTraceInFastThrow"]
     :dependencies
-    [[org.clojure/tools.namespace "1.2.0"]]}})
+    [[org.clojure/tools.namespace "1.3.0"]]}})

--- a/project.clj
+++ b/project.clj
@@ -11,7 +11,7 @@
   [[org.clojure/clojure "1.10.3"]
    [com.amperity/ken "1.0.1"]
    [com.stuartsierra/component "1.0.0"]
-   [io.honeycomb.libhoney/libhoney-java "1.4.1"]]
+   [io.honeycomb.libhoney/libhoney-java "1.5.0"]]
 
   :profiles
   {:dev


### PR DESCRIPTION
This PR updates this project's dependencies as revealed through `lein ancient` (sans `org.clojure/clojure`):

```
[com.amperity/ken "1.0.2"] is available but we use "1.0.1"
[com.stuartsierra/component "1.1.0"] is available but we use "1.0.0"
[org.clojure/tools.namespace "1.3.0"] is available but we use "1.2.0"
[org.slf4j/slf4j-nop "1.7.36"] is available but we use "1.7.35"
[io.honeycomb.libhoney/libhoney-java "1.5.0"] is available but we use "1.4.1"
```

Release version 1.0.3 will follow this upon merge.