### PR TITLE
Utility functions for adding span events and links

### DIFF
--- a/src/ken/honeycomb.clj
+++ b/src/ken/honeycomb.clj
@@ -26,14 +26,19 @@
   [event]
   (set/rename-keys
     event
-    {::event/label     :name
-     ::event/level     :level
-     ::event/message   :message
-     ::event/duration  :duration_ms
-     ;; ???            :service_name
+    {::event/label    :name
+     ::event/level    :level
+     ::event/message  :message
+     ::event/duration :duration_ms
+     ;; ???           :service_name
+
      ::trace/trace-id  :trace.trace_id
      ::trace/parent-id :trace.parent_id
-     ::trace/span-id   :trace.span_id}))
+     ::trace/span-id   :trace.span_id
+
+     :io.honeycomb/annotation-type :meta.annotation_type
+     :io.honeycomb/link-trace-id   :trace.link.trace_id
+     :io.honeycomb/link-span-id    :trace.link.span_id}))
 
 
 (defn- format-throwable


### PR DESCRIPTION
We use span links in our main application, so we should support them in the library directly. I also added support for span events, which will be useful for errors and other one-off events.

This uses `:io.honeycomb/annotation-type` and some similarly-namespaced keys for the link attributes, which is non-standard but matches our current usage. I've added these to the default name transformer, so anyone using that should have this work out of the box.

Fixes #4 