### PR TITLE
Conditionally set dataset per-event based on :service.name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Conditionally set dataset per-event based on the `:service.name` property,
   following the OTEL spec.
+  [PR#6](https://github.com/amperity/ken-honeycomb/pull/6)
 
 
 ## [1.1.0] - 2023-05-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-...
+### Changed
+- Conditionally set dataset per-event based on the `:service.name` property,
+  following the OTEL spec.
 
 
 ## [1.1.0] - 2023-05-08

--- a/src/ken/honeycomb.clj
+++ b/src/ken/honeycomb.clj
@@ -119,10 +119,12 @@
         (.setTimestamp event (inst-ms timestamp)))
       (when-let [sample-rate (::event/sample-rate data)]
         (.setSampleRate event (long sample-rate)))
+      ;; Follow OTEL spec and set dataset based on service.name.
+      (when-let [service-name (:service.name data)]
+        (.setDataset event service-name))
       ;; TODO: it's possible for events to override some of the client
       ;; properties; how should this be exposed?
       ;; - ApiHost
-      ;; - Dataset
       ;; - Metadata
       ;; - WriteKey
       event)))


### PR DESCRIPTION
Follow the OTEL spec and set the dataset per-event based on the `:service.name` property, if it's present.