### PR TITLE
Revert "Conditionally set dataset per-event based on :service.name (#6)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-...
+### Changed
+- Revert "Conditionally set dataset per-event based on the `:service.name`
+  property, following the OTEL spec."
+  [PR#7](https://github.com/amperity/ken-honeycomb/pull/7)
 
 
 ## [1.2.0] - 2023-08-14

--- a/src/ken/honeycomb.clj
+++ b/src/ken/honeycomb.clj
@@ -119,12 +119,10 @@
         (.setTimestamp event (inst-ms timestamp)))
       (when-let [sample-rate (::event/sample-rate data)]
         (.setSampleRate event (long sample-rate)))
-      ;; Follow OTEL spec and set dataset based on service.name.
-      (when-let [service-name (:service.name data)]
-        (.setDataset event service-name))
       ;; TODO: it's possible for events to override some of the client
       ;; properties; how should this be exposed?
       ;; - ApiHost
+      ;; - Dataset
       ;; - Metadata
       ;; - WriteKey
       event)))


### PR DESCRIPTION
This doesn't work properly with the batch `libhoney` consumer, since it sets the dataset for all events in the batch based on the dataset of the [first event](https://github.com/honeycombio/libhoney-java/blob/010211963db0dbc45af19d11755c8e363c3bbe56/libhoney/src/main/java/io/honeycomb/libhoney/transport/batch/impl/HoneycombBatchConsumer.java#L112).