### PR TITLE
Send presampled events to Honeycomb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   [PR#7](https://github.com/amperity/ken-honeycomb/pull/7)
 - Update dependency versions, including Clojure 1.12 and libhoney 1.6.
 
+### Fixed
+- Ken does its own down-sampling logic, so events should be sent "presampled"
+  to Honeycomb. Previously, the Honeycomb client would _also_ apply the sample
+  rate, resulting in unintentional double-sampling.
+
 
 ## [1.2.0] - 2023-08-14
 

--- a/src/ken/honeycomb.clj
+++ b/src/ken/honeycomb.clj
@@ -134,7 +134,7 @@
   [honeyclient transform data]
   (when-not (false? (::trace/keep? data))
     (when-let [event (create-event honeyclient transform data)]
-      (.send event))))
+      (.sendPresampled event))))
 
 
 ;; ## Client Construction


### PR DESCRIPTION
Ken does its own down-sampling logic, so events should be sent "presampled" to Honeycomb. Previously, the Honeycomb client would _also_ apply the sample rate, resulting in unintentional double-sampling. This means that a sample rate of 10 means you "see" 10% of the expected events in Honeycomb's UI, which is part of why we never noticed - however, that means you are only actually recording 1% of the events and Honeycomb is scaling the aggregates back up by 10x.

To fix this, we should be using the `sendPresampled` event method, which skips the `HoneyClient`'s internal downsampling logic.