### PR TITLE
Use :ken.trace/upstream-sampling for downsampled child spans

### DIFF
--- a/src/ken/honeycomb.clj
+++ b/src/ken/honeycomb.clj
@@ -101,7 +101,7 @@
   can handle as well as perform some data cleanup on the event."
   [transform event]
   (when-let [fields (-> event
-                        (dissoc ::event/time ::event/sample-rate)
+                        (dissoc ::event/time ::event/sample-rate ::trace/sample-rate)
                         (transform)
                         (not-empty))]
     (walk/prewalk format-value fields)))
@@ -117,7 +117,7 @@
       (.addFields event fields)
       (when-let [timestamp (::event/time data)]
         (.setTimestamp event (inst-ms timestamp)))
-      (when-let [sample-rate (::event/sample-rate data)]
+      (when-let [sample-rate (or (::event/sample-rate data) (::trace/sample-rate data))]
         (.setSampleRate event (long sample-rate)))
       ;; TODO: it's possible for events to override some of the client
       ;; properties; how should this be exposed?

--- a/src/ken/honeycomb.clj
+++ b/src/ken/honeycomb.clj
@@ -101,7 +101,7 @@
   can handle as well as perform some data cleanup on the event."
   [transform event]
   (when-let [fields (-> event
-                        (dissoc ::event/time ::event/sample-rate ::trace/sample-rate)
+                        (dissoc ::event/time ::event/sample-rate ::trace/upstream-sample-rate)
                         (transform)
                         (not-empty))]
     (walk/prewalk format-value fields)))
@@ -117,7 +117,7 @@
       (.addFields event fields)
       (when-let [timestamp (::event/time data)]
         (.setTimestamp event (inst-ms timestamp)))
-      (when-let [sample-rate (or (::event/sample-rate data) (::trace/sample-rate data))]
+      (when-let [sample-rate (or (::event/sample-rate data) (::trace/upstream-sample-rate data))]
         (.setSampleRate event (long sample-rate)))
       ;; TODO: it's possible for events to override some of the client
       ;; properties; how should this be exposed?

--- a/src/ken/honeycomb.clj
+++ b/src/ken/honeycomb.clj
@@ -101,7 +101,7 @@
   can handle as well as perform some data cleanup on the event."
   [transform event]
   (when-let [fields (-> event
-                        (dissoc ::event/time ::event/sample-rate ::trace/upstream-sample-rate)
+                        (dissoc ::event/time ::event/sample-rate ::trace/upstream-sampling)
                         (transform)
                         (not-empty))]
     (walk/prewalk format-value fields)))
@@ -117,7 +117,7 @@
       (.addFields event fields)
       (when-let [timestamp (::event/time data)]
         (.setTimestamp event (inst-ms timestamp)))
-      (when-let [sample-rate (or (::event/sample-rate data) (::trace/upstream-sample-rate data))]
+      (when-let [sample-rate (or (::event/sample-rate data) (::trace/upstream-sampling data))]
         (.setSampleRate event (long sample-rate)))
       ;; TODO: it's possible for events to override some of the client
       ;; properties; how should this be exposed?

--- a/test/ken/honeycomb_test.clj
+++ b/test/ken/honeycomb_test.clj
@@ -50,7 +50,7 @@
              :sym 'symbolic
              :ken.event/time (java.time.Instant/parse "1999-12-31T08:00:00.000Z")
              :ken.event/sample-rate 10
-             :ken.trace/sample-rate 10}))))
+             :ken.trace/upstream-sample-rate 10}))))
   (testing "honeycomb event fields"
     (is (= {"foo" "bar"}
            (#'hc/format-fields
@@ -58,7 +58,7 @@
             {:foo "bar"
              :ken.event/time (java.time.Instant/parse "1999-12-31T08:00:00.000Z")
              :ken.event/sample-rate 10
-             :ken.trace/sample-rate 10}))
+             :ken.trace/upstream-sample-rate 10}))
         "should not be included in field data"))
   (testing "collections"
     (is (= {"set" #{1 2 3}
@@ -160,7 +160,7 @@
               :fields {"foo" "bar"}}
              (-> (#'hc/create-event honeyclient identity {:foo "bar"
                                                           :ken.event/time mock-time
-                                                          :ken.trace/sample-rate 100})
+                                                          :ken.trace/upstream-sample-rate 100})
                  (get-event-data)))
           "should be set by :ken.event/sample-rate when provided")
       (is (= {:timestamp (inst-ms mock-time)
@@ -169,7 +169,7 @@
              (-> (#'hc/create-event honeyclient identity {:foo "bar"
                                                           :ken.event/time mock-time
                                                           :ken.event/sample-rate 10
-                                                          :ken.trace/sample-rate 100})
+                                                          :ken.trace/upstream-sample-rate 100})
                  (get-event-data)))
           "should prefer :ken.event/sample-rate if both provided (should only occur if user manipulates data by hand)"))
     (.close honeyclient)))

--- a/test/ken/honeycomb_test.clj
+++ b/test/ken/honeycomb_test.clj
@@ -1,7 +1,16 @@
 (ns ken.honeycomb-test
   (:require
     [clojure.test :refer [deftest testing is]]
-    [ken.honeycomb :as hc]))
+    [ken.honeycomb :as hc])
+  (:import
+    (io.honeycomb.libhoney
+      Event
+      HoneyClient
+      LibHoney)
+    (io.honeycomb.libhoney.responses
+      ResponseObservable)
+    (io.honeycomb.libhoney.transport
+      Transport)))
 
 
 (deftest event-processing
@@ -38,7 +47,19 @@
              :int 123
              :double 3.14
              :ratio 4/10
-             :sym 'symbolic}))))
+             :sym 'symbolic
+             :ken.event/time (java.time.Instant/parse "1999-12-31T08:00:00.000Z")
+             :ken.event/sample-rate 10
+             :ken.trace/sample-rate 10}))))
+  (testing "honeycomb event fields"
+    (is (= {"foo" "bar"}
+           (#'hc/format-fields
+            identity
+            {:foo "bar"
+             :ken.event/time (java.time.Instant/parse "1999-12-31T08:00:00.000Z")
+             :ken.event/sample-rate 10
+             :ken.trace/sample-rate 10}))
+        "should not be included in field data"))
   (testing "collections"
     (is (= {"set" #{1 2 3}
             "list" '("a")
@@ -72,3 +93,83 @@
                              {:foo 123
                               :bar true}
                              (RuntimeException. "BOOM"))})))))
+
+
+(defn- get-mock-honeyclient
+  "Mock honeyclient based on https://github.com/honeycombio/libhoney-java/blob/main/libhoney/src/main/java/io/honeycomb/libhoney/HoneyClient.java"
+  []
+  (let [mock-observable (proxy [ResponseObservable] []
+                          (add [observer] nil)
+
+                          (remove [observer] nil)
+
+                          (publish [response] nil))
+        mock-transport (reify Transport
+                         (submit [_this _event] true)
+
+                         (close [_this] nil)
+
+                         (getResponseObservable [_this] mock-observable))
+        options (-> (LibHoney/options)
+                    (.setWriteKey "test-key")
+                    (.setDataset "test-dataset")
+                    (.build))]
+    (HoneyClient. options mock-transport)))
+
+
+(defn- get-event-data
+  [^Event event]
+  {:sample-rate (.getSampleRate event)
+   :timestamp (.getTimestamp event)
+   :fields (.getFields event)})
+
+
+(deftest create-event-test
+  (let [mock-time (java.time.Instant/parse "1999-12-31T08:00:00.000Z")
+        honeyclient (get-mock-honeyclient)]
+    (testing "create-event fields"
+      (is (= {"foo" "bar"}
+             (-> (#'hc/create-event honeyclient identity {:foo "bar"
+                                                          :ken.event/time mock-time})
+                 (.getFields)))
+          "should be stored in epoch format"))
+    (testing "create-event timestamp"
+      (is (= (inst-ms mock-time)
+             (-> (#'hc/create-event honeyclient identity {:foo "bar"
+                                                          :ken.event/time mock-time})
+                 (.getTimestamp)))
+          "should be stored in epoch format"))
+    (testing "create-event sample-rate"
+      (is (= {:timestamp (inst-ms mock-time)
+              :sample-rate 1
+              :fields {"foo" "bar"}}
+             (-> (#'hc/create-event honeyclient identity {:foo "bar"
+                                                          :ken.event/time mock-time})
+                 (get-event-data)))
+          "should be 1 if not provided")
+      (is (= {:timestamp (inst-ms mock-time)
+              :sample-rate 10
+              :fields {"foo" "bar"}}
+             (-> (#'hc/create-event honeyclient identity {:foo "bar"
+                                                          :ken.event/time mock-time
+                                                          :ken.event/sample-rate 10})
+                 (get-event-data)))
+          "should be set by :ken.event/sample-rate when provided")
+      (is (= {:timestamp (inst-ms mock-time)
+              :sample-rate 100
+              :fields {"foo" "bar"}}
+             (-> (#'hc/create-event honeyclient identity {:foo "bar"
+                                                          :ken.event/time mock-time
+                                                          :ken.trace/sample-rate 100})
+                 (get-event-data)))
+          "should be set by :ken.event/sample-rate when provided")
+      (is (= {:timestamp (inst-ms mock-time)
+              :sample-rate 10
+              :fields {"foo" "bar"}}
+             (-> (#'hc/create-event honeyclient identity {:foo "bar"
+                                                          :ken.event/time mock-time
+                                                          :ken.event/sample-rate 10
+                                                          :ken.trace/sample-rate 100})
+                 (get-event-data)))
+          "should prefer :ken.event/sample-rate if both provided (should only occur if user manipulates data by hand)"))
+    (.close honeyclient)))

--- a/test/ken/honeycomb_test.clj
+++ b/test/ken/honeycomb_test.clj
@@ -50,7 +50,7 @@
              :sym 'symbolic
              :ken.event/time (java.time.Instant/parse "1999-12-31T08:00:00.000Z")
              :ken.event/sample-rate 10
-             :ken.trace/upstream-sample-rate 10}))))
+             :ken.trace/upstream-sampling 10}))))
   (testing "honeycomb event fields"
     (is (= {"foo" "bar"}
            (#'hc/format-fields
@@ -58,7 +58,7 @@
             {:foo "bar"
              :ken.event/time (java.time.Instant/parse "1999-12-31T08:00:00.000Z")
              :ken.event/sample-rate 10
-             :ken.trace/upstream-sample-rate 10}))
+             :ken.trace/upstream-sampling 10}))
         "should not be included in field data"))
   (testing "collections"
     (is (= {"set" #{1 2 3}
@@ -160,7 +160,7 @@
               :fields {"foo" "bar"}}
              (-> (#'hc/create-event honeyclient identity {:foo "bar"
                                                           :ken.event/time mock-time
-                                                          :ken.trace/upstream-sample-rate 100})
+                                                          :ken.trace/upstream-sampling 100})
                  (get-event-data)))
           "should be set by :ken.event/sample-rate when provided")
       (is (= {:timestamp (inst-ms mock-time)
@@ -169,7 +169,7 @@
              (-> (#'hc/create-event honeyclient identity {:foo "bar"
                                                           :ken.event/time mock-time
                                                           :ken.event/sample-rate 10
-                                                          :ken.trace/upstream-sample-rate 100})
+                                                          :ken.trace/upstream-sampling 100})
                  (get-event-data)))
           "should prefer :ken.event/sample-rate if both provided (should only occur if user manipulates data by hand)"))
     (.close honeyclient)))


### PR DESCRIPTION
# Summary

[amperity/ken#13](https://github.com/amperity/ken/pull/13) adds :ken.trace/sample-rate so that child spans of a downsampled event have enough information to correctly calculate COUNT and SUM aggregations

# Testing

1. Add coverage in existing test cases against `format-fields`
2. Add new test coverage for `create-event` covering both this change and extant behavior

# Rollout

This PR should be merged/deployed first for a clean rollout. Otherwise datasets will get a `ken.trace/sample-rate` field added to them