### PR TITLE
add-span-link: link-event builder + explicit-span arity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
-...
+### Added
+- `link-event` builds a Honeycomb "link" annotation from a span (a span map or
+  explicit ids) without enriching or sending it, so callers with no ambient
+  trace context (e.g. Rama dataflow) can compose their own enrichment before
+  sending. `add-span-link` now builds on it.
 
 ## [1.4.1] - 2026-02-10
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.amperity/ken-honeycomb "1.4.1"
+(defproject com.amperity/ken-honeycomb "1.5.0"
   :description "Observability library to integrate ken and honeycomb"
   :url "https://github.com/amperity/ken-honeycomb"
   :license {:name "MIT License"

--- a/src/ken/honeycomb.clj
+++ b/src/ken/honeycomb.clj
@@ -261,6 +261,30 @@
       (tap/send)))
 
 
+(defn link-event
+  "Builds (without sending) a Honeycomb \"link\" annotation from a source span (a
+  span map or explicit ids) to a target. Returns nil when a source id or both
+  targets are absent."
+  ([from-span target-trace target-span]
+   (link-event (::trace/trace-id from-span) (::trace/span-id from-span)
+               target-trace target-span))
+  ([current-trace current-span target-trace target-span]
+   (when (and current-trace
+              current-span
+              (or target-trace
+                  target-span))
+     (cond->
+       {::event/time (event/now)
+        ::event/level :trace
+        ::trace/trace-id current-trace
+        ::trace/parent-id current-span
+        :io.honeycomb/annotation-type "link"}
+       target-trace
+       (assoc :io.honeycomb/link-trace-id target-trace)
+       target-span
+       (assoc :io.honeycomb/link-span-id target-span)))))
+
+
 (defn add-span-link
   "Add a link from the identified (or current) span to another trace or span."
   ([target-trace target-span]
@@ -269,23 +293,9 @@
          current-span (::trace/span-id current-data)]
      (add-span-link current-trace current-span target-trace target-span)))
   ([current-trace current-span target-trace target-span]
-   (when (and current-trace
-              current-span
-              (or target-trace
-                  target-span))
-     (->
-       {::event/time (event/now)
-        ::event/level :trace
-        ::trace/trace-id current-trace
-        ::trace/parent-id current-span
-        :io.honeycomb/annotation-type "link"}
-       (cond->
-         target-trace
-         (assoc :io.honeycomb/link-trace-id target-trace)
-         target-span
-         (assoc :io.honeycomb/link-span-id target-span))
-       (ken/enrich-span)
-       (tap/send)))))
+   (some-> (link-event current-trace current-span target-trace target-span)
+           (ken/enrich-span)
+           (tap/send))))
 
 
 (defmacro watch-linked

--- a/test/ken/honeycomb_test.clj
+++ b/test/ken/honeycomb_test.clj
@@ -173,3 +173,24 @@
                  (get-event-data)))
           "should prefer :ken.event/sample-rate if both provided (should only occur if user manipulates data by hand)"))
     (.close honeyclient)))
+
+
+(def ^:private real-trace "0123456789abcdef0123456789abcdef")
+(def ^:private real-span "0123456789abcdef")
+
+
+(deftest link-event-test
+  (testing "builds a link annotation from a source span to a target"
+    (is (= {:ken.event/level :trace
+            :ken.trace/trace-id "cur-trace"
+            :ken.trace/parent-id "cur-span"
+            :io.honeycomb/annotation-type "link"
+            :io.honeycomb/link-trace-id real-trace
+            :io.honeycomb/link-span-id real-span}
+           (dissoc (hc/link-event {:ken.trace/trace-id "cur-trace"
+                                   :ken.trace/span-id "cur-span"}
+                                  real-trace real-span)
+                   :ken.event/time))))
+  (testing "returns nil when a source id or both targets are missing"
+    (is (nil? (hc/link-event nil nil real-trace real-span)))
+    (is (nil? (hc/link-event "cur-trace" "cur-span" nil nil)))))


### PR DESCRIPTION
Improve `ken.honeycomb/add-span-link` so callers with no ambient ken trace context (e.g. Rama dataflow, which carries spans explicitly) can build a link and enrich it before sending.

## Why

`add-span-link` reads `trace/current-data` (2-arity) or takes loose ids (4-arity), and always enriches-and-sends in one call. Callers that need to add fields to the link before sending (e.g. Rama dataflow attaching task context and sampling, with the span passed explicitly) cannot reuse it.

## Changes

- `link-event`: pure builder returning the `"link"` annotation event without enriching or sending, with a span-map arity. Returns nil when the source ids or both target ids are missing.
- `add-span-link`: add a span-map arity; all arities route through `link-event`. The 2-arity (current span) and 4-arity (used by `watch-linked`) behave as before.

Additive only, no behavior change for existing callers. Version 1.4.1 -> 1.5.0.

## Downstream

amperity/app PR #68635 (DEQ tracing) depends on 1.5.0 and calls `link-event` from a Rama helper that adds task context and sampling. [LOOM-1827]

## Testing

`lein test` (3 tests / 22 assertions, 0 failures). New `link-event-test` covers the field shape, the span-map arity, one-sided targets, and the missing-id no-op.


[LOOM-1827]: https://amperity.atlassian.net/browse/LOOM-1827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ